### PR TITLE
Only reference System.Diagnostics.Debug from the .NET Standard 1.0 build

### DIFF
--- a/src/Serilog.Sinks.Debug/Serilog.Sinks.Debug.csproj
+++ b/src/Serilog.Sinks.Debug/Serilog.Sinks.Debug.csproj
@@ -20,7 +20,7 @@
     <GenerateAssemblyFileVersionAttribute>true</GenerateAssemblyFileVersionAttribute>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <!-- Don't reference the full NETStandard.Library -->
-    <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
+    <DisableImplicitFrameworkReferences Condition=" '$(TargetFramework)' == 'netstandard1.0' ">true</DisableImplicitFrameworkReferences>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     <TreatSpecificWarningsAsErrors />
     <RootNamespace>Serilog</RootNamespace>
@@ -33,6 +33,9 @@
 
   <ItemGroup>
     <PackageReference Include="Serilog" Version="2.5.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.0' ">
     <PackageReference Include="System.Diagnostics.Debug" Version="4.3.0" />
   </ItemGroup>
 


### PR DESCRIPTION
refs #6.

I dont *think* the reference to the ```System.Diagnostics.Debug``` package should be needed for any of the current target frameworks other than ```netstandard1.0```, but the reference to the in-box version is currently disabled due to the ```DisableImplicitFrameworkReferences``` setting.

This change changes the project so that ```DisableImplicitFrameworkReferences``` is only set for ```netstandard1.0``` so that the other targets pick up the inbox version. I'm not entirely sure what the situation is with DisableImplicitFrameworkReferences though as I'd thought the idea was to remove avoid dependency chains when referencing old netstandard versions from full .net, but it looks like some of the other Serilog libs set that for just netstandard and some set it for full framework builds as well?

Related: I don't think a reference to System.Diagnostics.Debug would be needed for a netstandard1.3 build either, not sure if there is a point in adding older versions at targets now though.