### PR TITLE
Float serilog version (4.*) to improve compatibility with other packages

### DIFF
--- a/src/Serilog.Sinks.Debug/Serilog.Sinks.Debug.csproj
+++ b/src/Serilog.Sinks.Debug/Serilog.Sinks.Debug.csproj
@@ -35,7 +35,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Serilog" Version="4.0.0" />
+    <PackageReference Include="Serilog" Version="4.*" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
**Motivation**:
Currently cannot use Serilog 4.2.0 with Serilog.Sinks.Debug without nuget warnings. I would like to use the latest serilog version for stuff I am working on :)

**Changes**:
Updates the .csproj to allow Serilog versions to float to the required/latest serilog minor rev.
